### PR TITLE
cd FireShort-master =>  No such file or directory Error Solve

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ git clone https://github.com/monizb/FireShort.git
 Head inside the cloned folder and install the dependencies using NPM
 
 ```sh
-$ cd FireShort-master
+$ cd FireShort
 $ npm install
 ```
 


### PR DESCRIPTION
$ cd FireShort-master
bash: cd: FireShort-master: No such file or directory

"An Unexpected Error Occurred" When we clone that project and change Directory

**Update Readme**

### What is the current behavior?
When we write
$ cd FireShort-master
Error Occurred like  No such file or directory

### What is the new behavior?
$ cd FireShort-master  
change to =>
$ cd FireShort

**Error Resolve**

