### PR TITLE
Added the functionality to stop circular progressbar in login button in case of failed authentication

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -18,7 +18,7 @@ const styles = () => ({
   paper: {
     marginTop: 100,
     display: "flex",
-    padding: 20,
+    padding: 40,
     flexDirection: "column",
     alignItems: "center",
   },
@@ -59,7 +59,7 @@ class Login extends Component {
     } else {
       return (
         <Container component="main" maxWidth="xs">
-          <Paper className={classes.paper}>
+          <Paper className={classes.paper} elevation={3}>
             <Avatar className={classes.avatar} src="/favicon.ico"></Avatar>
             <Typography component="h1" variant="h5">
               FireShort
@@ -100,7 +100,7 @@ class Login extends Component {
                 className={classes.submit}
               >
                 <MuiThemeProvider theme={theme}>
-                  {isLoading ? (
+                  {isLoading && !loginError ? (
                     <CircularProgress color="secondary" />
                   ) : (
                     "Sign In"


### PR DESCRIPTION
…per login

### Please check if the PR fulfills these requirements:

* [ ] The PR title and message describe the solution briefly.
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
The circular progressbar in the login page keeps scrolling in case of failed authentication, hence I added the check to stop it when the authentication fails.

### What is the new behavior?

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
