### PR TITLE
Issue #74: Fixing the bug of hiding the loader

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -39,7 +39,7 @@ class Home extends Component {
         .get()
         .then((doc) => {
           var data = doc.data();
-          this.setState({ loading: false, realPassword: data.password });
+          this.setState({ realPassword: data.password });
           if (!doc.exists) {
             window.location.pathname = "/login";
           } else {
@@ -72,7 +72,7 @@ class Home extends Component {
                 })();
               }
             } else {
-              this.setState({ isLocked: true });
+              this.setState({ loading: false, isLocked: true });
             }
           }
         })


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message describe the solution briefly.
* [ ] Documentation has been updated/added if relevant
* [ ] I am not raising a spam PR or a PR that fixes spellings or whitespaces for Hacktoberfest
* [ ] I know that if this PR is found to be spam, It will be labeled and reported immediately

### What is the current behavior?
When we go to the shortened link the loader hides itself before the app start redirecting to the shortened link page.

### What is the new behavior?
Loader stays visible until the link we shortened starts to redirect from the app.

