### PR TITLE
Implement Password Protection in Card Layout

### DIFF
--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -411,6 +411,7 @@ class Admin extends Component {
                   handleDeleteShortUrl={this.handleDeleteShortUrl}
                   openHits={this.getHits}
                 // updateHits={this.updateUrls}
+                  toggleSecurity={this.toggleSecurity}
                 />
               ) : (
                   <ListUrls

--- a/src/components/CardUrls.js
+++ b/src/components/CardUrls.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Box, Button, Card, CardContent, CardHeader, Container, CardActions, Grid, IconButton, Tooltip, Typography } from '@material-ui/core';
+import { Box, Card, CardContent, CardHeader, Container, CardActions, Grid, IconButton, Tooltip, Typography } from '@material-ui/core';
 import Chip from '@material-ui/core/Chip';
 import Badge from '@material-ui/core/Badge';
 import {

--- a/src/components/CardUrls.js
+++ b/src/components/CardUrls.js
@@ -1,10 +1,17 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Box, Button, Card, CardContent, CardHeader, Container, CardActions, Grid, IconButton, Tooltip, Typography } from '@material-ui/core';
-import { FileCopyOutlined as FileCopyOutlinedIcon } from '@material-ui/icons';
 import Chip from '@material-ui/core/Chip';
 import Badge from '@material-ui/core/Badge';
-import { OpenInBrowser } from '@material-ui/icons';
+import {
+    FileCopyOutlined as FileCopyOutlinedIcon,
+    OpenInBrowser,
+    Edit as EditIcon,
+    Visibility as VisibilityIcon,
+    DeleteForever as DeleteForeverIcon,
+    Lock as LockIcon,
+    LockOpen as LockOpenIcon
+ } from '@material-ui/icons';
 
 const useStyles = makeStyles((theme) => ({
     cardGrid: {
@@ -21,6 +28,9 @@ const useStyles = makeStyles((theme) => ({
     },
     cardContent: {
         flexGrow: 1,
+    },
+    cardActions: {
+        justifyContent: "space-around",
     },
     copyButton: {
         justifyContent: "flex-end",
@@ -64,23 +74,26 @@ export default function CardUrls(props) {
                                     {card.data.lurl}
                                 </Box>
                             </CardContent>
-                            <CardActions>
-                                <Button size="small" color="primary" href={card.data.lurl} target="_blank">
-                                    Open
-                                </Button>
-                                <Button size="small" onClick={() => props.handleEditShortUrl(card.data.curl)}>
-                                    Edit
-                                </Button>
-                                <Button size="small" color="secondary" onClick={() => props.handleDeleteShortUrl(card.data.curl)}>
-                                    Delete
-                                </Button>
+                            <CardActions className={classes.cardActions}>
+                                <IconButton size="small" color="primary" href={card.data.lurl} target="_blank">
+                                    <VisibilityIcon />
+                                </IconButton>
+                                <IconButton size="small" onClick={() => props.handleEditShortUrl(card.data.curl)}>
+                                    <EditIcon />
+                                </IconButton>
+                                <IconButton size="small" color="secondary" onClick={() => props.handleDeleteShortUrl(card.data.curl)}>
+                                    <DeleteForeverIcon />
+                                </IconButton>
                                 <Tooltip title={card.data.hits + " Hits"}>
-                                    <div onClick={() => { props.openHits(card.data.curl) }} style={{ cursor: "pointer" }}>
+                                    <IconButton onClick={() => { props.openHits(card.data.curl) }} style={{ cursor: "pointer" }}>
                                         <Badge badgeContent={card.data.hits} color="secondary" max={Infinity} showZero>
                                             <OpenInBrowser />
                                         </Badge>
-                                    </div>
+                                    </IconButton>
                                 </Tooltip>
+                                <IconButton size='small' color='default' onClick={() => props.toggleSecurity(card.data.curl)}>
+                                    {card.data.locked ? <LockIcon /> : <LockOpenIcon />}
+                                </IconButton>
                             </CardActions>
                         </Card>
                     </Grid>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message describe the solution briefly.
* [ ] Documentation has been updated/added if relevant
* [ ] I am not raising a spam PR or a PR that fixes spellings or whitespaces for Hacktoberfest
* [ ] I know that if this PR is found to be spam, It will be labeled and reported immediately

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
There was no icon to set or unset password on a link in Card Layout.

### What is the new behavior?
Now, added the lock icon in Card layout. To provide room for it in Card actions, converted all other buttons from Text buttons to Icon buttons.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
