### PR TITLE
Issue #80: Adding space as a short url breaks the app (fix)

### DIFF
--- a/src/components/UrlsDialog.js
+++ b/src/components/UrlsDialog.js
@@ -45,6 +45,12 @@ function isUrl(s) {
     return regexp.test(s);
 }
 
+function hasSpaces(s){
+    var regexp = /\s/;  
+    console.log(regexp.test(s))  
+    return regexp.test(s);
+}
+
 export default function UrlsDialog(props) {
     const [open, setOpen] = React.useState(false);
     const handleClick = () => {
@@ -123,7 +129,7 @@ export default function UrlsDialog(props) {
                     Cancel
               </Button>
                 <Button onClick={() => {
-                    if (isUrl(props.state.lurl)) {
+                    if (isUrl(props.state.lurl) && !hasSpaces(props.state.curl)) {
                         props.handleSubmit()
                     } else {
                         handleClick()
@@ -133,9 +139,9 @@ export default function UrlsDialog(props) {
               </Button>
                 <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
                     <Alert onClose={handleClose} severity="error" variant="filled">
-                        Enter a valid URL to shorten
-  </Alert>
-                </Snackbar>
+                        {!isUrl(props.state.lurl) ? "Enter a valid URL to shorten" : "Enter a custom URL without spaces"}
+                    </Alert>
+                </Snackbar>                
             </DialogActions>
         </Dialog>
     );


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] The PR title and message describe the solution briefly.
* [ ] Documentation has been updated/added if relevant
* [ ] I am not raising a spam PR or a PR that fixes spellings or whitespaces for Hacktoberfest
* [ ] I know that if this PR is found to be spam, It will be labeled and reported immediately

### What is the current behavior?
It is possible to create Custom URL (Short url) with spaces, in that way when trying to go to that URL the loader is visible constantly, the redirect doesn't happen and in console we get error of an undefined property

### What is the new behavior?
When creating Custom URL there is a check if there are spaces in it's name. In cases of spaces the link will not be shortened and we get a message that the Custom URL cannot contain spaces. The funcionality that was before regarding the original link remains the same, if both input fields have errors (not valid URL or custom URL with spaces), the message we get is for invalid URL, if we put a valid URL we get the message of spaces in custom URL input field.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
